### PR TITLE
invalid-class-range

### DIFF
--- a/lib/wild/tokenizer.ex
+++ b/lib/wild/tokenizer.ex
@@ -110,12 +110,17 @@ defmodule Wild.Tokenizer do
 
       # Ending the current class
       defp do_tokenize_pattern([{unquote(right_square_bracket), _next_token} | tail], acc, class) when is_list(class) do
-        class =
+        normalized_class_result =
           class
           |> Enum.reverse()
           |> normalize_class()
 
-        do_tokenize_pattern(tail, [class | acc], nil)
+        case normalized_class_result do
+          {:ok, normalized_class} ->
+            do_tokenize_pattern(tail, [normalized_class | acc], nil)
+          error ->
+            error
+        end
       end
 
       # In a class - Regular token
@@ -149,34 +154,39 @@ defmodule Wild.Tokenizer do
 
         [_ | zipped] = all_zipped
 
-        zipped
-        |> normalize_class([])
-        |> Enum.into(map_set)
+        case do_normalize_class(zipped, []) do
+          {:ok, normalized} -> {:ok, Enum.into(normalized, map_set)}
+          error -> error
+        end
       end
 
       # Base case - turn list into MapSet
-      defp normalize_class([], acc) do
-        MapSet.new(acc)
+      defp do_normalize_class([], acc) do
+        {:ok, MapSet.new(acc)}
       end
 
       # A dash at the start of the class should be treated literally
-      defp normalize_class([{nil, unquote(dash), _next} | tail], acc) do
-        normalize_class(tail, [unquote(dash) | acc])
+      defp do_normalize_class([{nil, unquote(dash), _next} | tail], acc) do
+        do_normalize_class(tail, [unquote(dash) | acc])
       end
 
       # A dash at the end of the class should be treated literally
-      defp normalize_class([{_prev, unquote(dash), nil} | tail], acc) do
-        normalize_class(tail, [unquote(dash) | acc])
+      defp do_normalize_class([{_prev, unquote(dash), nil} | tail], acc) do
+        do_normalize_class(tail, [unquote(dash) | acc])
       end
 
       # A range, expand it and and each member
-      defp normalize_class([{range_start, unquote(dash), range_end} | tail], acc) do
-        normalize_class(tail, range_to_list(range_start, range_end) ++ acc)
+      defp do_normalize_class([{range_start, unquote(dash), range_end} | tail], acc) when range_start <= range_end do
+        do_normalize_class(tail, range_to_list(range_start, range_end) ++ acc)
+      end
+      # An invalid range, the start needs to be less-than-or-equal-to the end
+      defp do_normalize_class([{_range_start, unquote(dash), _range_end} | _tail], _acc) do
+        {:error, :invalid_class}
       end
 
       # A non-special token
-      defp normalize_class([{_prev, token, _next} | tail], acc) do
-        normalize_class(tail, [token | acc])
+      defp do_normalize_class([{_prev, token, _next} | tail], acc) do
+        do_normalize_class(tail, [token | acc])
       end
     end
   end

--- a/test/wild/codepoint_test.exs
+++ b/test/wild/codepoint_test.exs
@@ -58,6 +58,7 @@ defmodule Wild.CodepointTest do
 
     test "returns error for invalid class" do
       assert {:error, :invalid_class} == Codepoint.tokenize_pattern("[!]")
+      assert {:error, :invalid_class} == Codepoint.tokenize_pattern("[a--]")
     end
   end
 


### PR DESCRIPTION
Fixes a bug where characters in a range were being permitted in a descending order.  The example class from the test was:

```
[j--]
```

where the range going from `j` to `-` means going from values `106` to `45` which is not ascending order.